### PR TITLE
Add cheat mode with animated gradient and performance optimizations

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,10 +46,10 @@ function App() {
 
   // Check for game completion
   useEffect(() => {
-    if (gameHook.gameState.isGameCompleted && !showCompletion) {
+    if (gameHook.gameState.isGameCompleted && !gameHook.gameState.hasShownEndingVideo && !showCompletion) {
       setShowCompletion(true);
     }
-  }, [gameHook.gameState.isGameCompleted, showCompletion]);
+  }, [gameHook.gameState.isGameCompleted, gameHook.gameState.hasShownEndingVideo, showCompletion]);
 
   const handleIntroTransition = () => {
     // Placeholder for any transition logic
@@ -61,6 +61,8 @@ function App() {
 
   const handleCompletionComplete = () => {
     setShowCompletion(false);
+    // Transition to endless mode after video is closed
+    gameHook.handleTransitionToEndless();
   };
 
   return (
@@ -81,6 +83,8 @@ function App() {
       <GameCompletion
         isVisible={showCompletion}
         onComplete={handleCompletionComplete}
+        gameMode={gameHook.gameState.gameMode}
+        onMarkVideoShown={gameHook.handleMarkVideoShown}
       />
     </div>
   );
@@ -115,7 +119,6 @@ function GameComponent({
   // Audio settings state
   const [soundEffectsVolume, setSoundEffectsVolume] = useState(0.3);
   const [musicVolume, setMusicVolume] = useState(0.7); // Increased from 0.35 to 0.7 (70%)
-  
 
   
 
@@ -191,7 +194,9 @@ function GameComponent({
           setBackgroundMusicVolume(volume);
         }}
         
-        
+        // Cheat mode
+        cheatMode={gameState.cheatMode}
+        onCheatModeChange={gameHook.handleToggleCheatMode}
       />
 
       {/* Toast Notifications - Aligned with blob horizontally */}

--- a/src/components/GameCompletion.tsx
+++ b/src/components/GameCompletion.tsx
@@ -4,9 +4,16 @@ import { pauseBackgroundMusic, playBackgroundMusic } from '../utils/sound';
 interface GameCompletionProps {
   isVisible: boolean;
   onComplete: () => void;
+  gameMode?: 'tutorial' | 'main' | 'endless';
+  onMarkVideoShown?: () => void;
 }
 
-export const GameCompletion: React.FC<GameCompletionProps> = ({ isVisible, onComplete }) => {
+export const GameCompletion: React.FC<GameCompletionProps> = ({ 
+  isVisible, 
+  onComplete, 
+  gameMode = 'main',
+  onMarkVideoShown
+}) => {
   const [showVideo, setShowVideo] = useState(false);
   const [hasClosed, setHasClosed] = useState(false);
 
@@ -35,9 +42,21 @@ export const GameCompletion: React.FC<GameCompletionProps> = ({ isVisible, onCom
     
     setHasClosed(true);
     setShowVideo(false);
+    
+    // Mark the video as shown so it doesn't reopen
+    onMarkVideoShown?.();
+    
     onComplete();
     // Resume background music when video ends
     playBackgroundMusic(0.24);
+  };
+
+  const handleRewatchEnding = () => {
+    // Reset the closed state and show video again
+    setHasClosed(false);
+    setShowVideo(true);
+    pauseBackgroundMusic();
+    // Note: We don't call onMarkVideoShown here because this is a rewatch
   };
 
   const handleKeyPress = (event: KeyboardEvent) => {
@@ -142,6 +161,43 @@ export const GameCompletion: React.FC<GameCompletionProps> = ({ isVisible, onCom
             ✕
           </button>
         </div>
+      )}
+
+      {/* Rewatch Ending Button - Only show in endless mode when video is not playing */}
+      {gameMode === 'endless' && !showVideo && (
+        <button
+          onClick={handleRewatchEnding}
+          style={{
+            position: 'absolute',
+            bottom: '20px',
+            right: '20px',
+            zIndex: 2,
+            backgroundColor: 'rgba(0, 0, 0, 0.7)',
+            color: 'white',
+            border: '2px solid white',
+            borderRadius: '8px',
+            padding: '10px 15px',
+            fontSize: '14px',
+            cursor: 'pointer',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            fontFamily: 'Arial, sans-serif',
+            pointerEvents: 'auto',
+            transition: 'all 0.2s ease',
+          }}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.backgroundColor = 'rgba(0, 0, 0, 0.9)';
+            e.currentTarget.style.transform = 'scale(1.05)';
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.backgroundColor = 'rgba(0, 0, 0, 0.7)';
+            e.currentTarget.style.transform = 'scale(1)';
+          }}
+          title="Rewatch the ending video"
+        >
+          🎬 Rewatch Ending
+        </button>
       )}
 
       <style>{`

--- a/src/components/generators/GeneratorVisualization.tsx
+++ b/src/components/generators/GeneratorVisualization.tsx
@@ -58,7 +58,9 @@ export const GeneratorVisualization: React.FC<GeneratorVisualizationProps> = ({
     const emojis: GeneratorEmoji[] = [];
 
     // Get active generators (with levels > 0), excluding tutorial generator
-    const activeGenerators = Object.values(gameState.generators).filter(gen => gen.level > 0 && gen.id !== 'tutorial-generator');
+    const activeGenerators = Object.values(gameState.generators).filter(gen => 
+      gen.level > 0 && gen.id !== 'tutorial-generator' && gen.id !== 'cheat-generator'
+    );
 
     if (activeGenerators.length === 0) return emojis;
 

--- a/src/components/hud/Evolution/EvolutionButton.tsx
+++ b/src/components/hud/Evolution/EvolutionButton.tsx
@@ -9,6 +9,7 @@ interface EvolutionButtonProps {
   onEvolve?: () => void;
   currentLevelId?: number; // Add current level ID to determine button text
   isGameCompleted?: boolean;
+  gameMode?: 'tutorial' | 'main' | 'endless';
 }
 
 export const EvolutionButton: React.FC<EvolutionButtonProps> = ({
@@ -17,6 +18,7 @@ export const EvolutionButton: React.FC<EvolutionButtonProps> = ({
   onEvolve,
   currentLevelId = 0,
   isGameCompleted = false,
+  gameMode = 'main',
 }) => {
   const startIntro = useIntroStore(state => state.startIntro);
 
@@ -39,7 +41,9 @@ export const EvolutionButton: React.FC<EvolutionButtonProps> = ({
           }}
         >
           {isGameCompleted 
-            ? "🌌 You have conquered the galaxy! The universe is yours to command."
+            ? gameMode === 'endless'
+              ? "🌌 You have conquered the galaxy! Continue your endless expansion..."
+              : "🌌 You have conquered the galaxy! The universe is yours to command."
             : "🏆 You've reached the maximum evolution level! There are no more universes to conquer."
           }
         </p>

--- a/src/components/hud/Evolution/EvolutionPanel.tsx
+++ b/src/components/hud/Evolution/EvolutionPanel.tsx
@@ -43,6 +43,10 @@ interface EvolutionPanelProps {
   // Blob effects
   clickSensitivity?: "low" | "normal" | "high";
   onClickSensitivityChange?: (value: "low" | "normal" | "high") => void;
+  
+  // Cheat mode
+  cheatMode?: boolean;
+  onCheatModeChange?: (value: boolean) => void;
 }
 
 export const EvolutionPanel: React.FC<EvolutionPanelProps> = ({
@@ -71,6 +75,9 @@ export const EvolutionPanel: React.FC<EvolutionPanelProps> = ({
   musicVolume = 0.35,
   onMusicVolumeChange,
   
+  // Cheat mode
+  cheatMode,
+  onCheatModeChange,
 
 }) => {
   if (!gameState) return null;
@@ -151,6 +158,7 @@ export const EvolutionPanel: React.FC<EvolutionPanelProps> = ({
         onEvolve={onEvolve}
         currentLevelId={currentLevel.id}
         isGameCompleted={gameState.isGameCompleted}
+        gameMode={gameState.gameMode}
       />
 
       {/* Spacer to push customization to bottom */}
@@ -197,7 +205,9 @@ export const EvolutionPanel: React.FC<EvolutionPanelProps> = ({
           musicVolume={musicVolume}
           onMusicVolumeChange={onMusicVolumeChange || (() => {})}
           
-
+          // Cheat mode
+          cheatMode={cheatMode || false}
+          onCheatModeChange={onCheatModeChange || (() => {})}
         />
       </div>
     </div>

--- a/src/components/hud/GameHUD.tsx
+++ b/src/components/hud/GameHUD.tsx
@@ -36,7 +36,9 @@ export const GameHUD: React.FC<GameHUDProps> = ({
   musicVolume = 0.35,
   onMusicVolumeChange,
   
-
+  // Cheat mode
+  cheatMode = false,
+  onCheatModeChange,
 }) => {
   const blobPosition = calculateBlobPosition();
   const shopWidth = 350;
@@ -79,6 +81,7 @@ export const GameHUD: React.FC<GameHUDProps> = ({
           tutorialState={tutorialState}
           onBuyGenerator={onBuyGenerator}
           onBuyUpgrade={onBuyUpgrade}
+          cheatMode={cheatMode}
         />
       </div>
 
@@ -110,6 +113,9 @@ export const GameHUD: React.FC<GameHUDProps> = ({
           musicVolume={musicVolume}
           onMusicVolumeChange={onMusicVolumeChange}
           
+          // Cheat mode
+          cheatMode={cheatMode}
+          onCheatModeChange={onCheatModeChange}
 
         />
       )}

--- a/src/components/hud/Shop/BuyMultiplierToggle.tsx
+++ b/src/components/hud/Shop/BuyMultiplierToggle.tsx
@@ -2,13 +2,15 @@ import React from "react";
 import { Colors } from "../../../styles/colors";
 
 interface BuyMultiplierToggleProps {
-  multiplier: 1 | 10 | 50;
-  onMultiplierChange: (multiplier: 1 | 10 | 50) => void;
+  multiplier: 1 | 10 | 50 | 'double';
+  onMultiplierChange: (multiplier: 1 | 10 | 50 | 'double') => void;
+  cheatMode?: boolean;
 }
 
 export const BuyMultiplierToggle: React.FC<BuyMultiplierToggleProps> = ({
   multiplier,
   onMultiplierChange,
+  cheatMode = false,
 }) => {
   return (
     <div
@@ -74,6 +76,36 @@ export const BuyMultiplierToggle: React.FC<BuyMultiplierToggleProps> = ({
       >
         Buy 50
       </button>
+      {cheatMode && (
+        <button
+          onClick={() => onMultiplierChange('double')}
+          style={{
+            padding: "4px 8px",
+            fontSize: "12px",
+            background: "linear-gradient(45deg, #ff69b4, #ff1493, #8a2be2, #4b0082, #ff69b4, #ff1493)",
+            backgroundSize: "300% 300%",
+            animation: "shimmer 2s linear infinite",
+            color: "#fff",
+            border: "none",
+            borderRadius: "4px",
+            cursor: "pointer",
+            fontWeight: multiplier === 'double' ? "bold" : "normal",
+            textAlign: "center",
+            boxShadow: multiplier === 'double' ? "0 0 15px rgba(255, 105, 180, 0.8)" : "0 0 8px rgba(255, 105, 180, 0.5)",
+            opacity: multiplier === 'double' ? 1 : 0.8,
+            transition: "opacity 0.2s ease, box-shadow 0.2s ease, font-weight 0.2s ease",
+          }}
+        >
+          2x
+        </button>
+      )}
+      <style>{`
+        @keyframes shimmer {
+          0% { background-position: 0% 50%; }
+          50% { background-position: 100% 50%; }
+          100% { background-position: 0% 50%; }
+        }
+      `}</style>
     </div>
   );
 };

--- a/src/components/hud/Shop/CustomizationToggles.tsx
+++ b/src/components/hud/Shop/CustomizationToggles.tsx
@@ -22,7 +22,9 @@ interface CustomizationTogglesProps {
   musicVolume: number;
   onMusicVolumeChange: (value: number) => void;
   
-
+  // Cheat mode
+  cheatMode: boolean;
+  onCheatModeChange: (value: boolean) => void;
 }
 
 export const CustomizationToggles: React.FC<CustomizationTogglesProps> = ({
@@ -46,6 +48,9 @@ export const CustomizationToggles: React.FC<CustomizationTogglesProps> = ({
   musicVolume,
   onMusicVolumeChange,
   
+  // Cheat mode
+  cheatMode,
+  onCheatModeChange,
 
 }) => {
   const toggleButtonStyle = {
@@ -264,6 +269,31 @@ export const CustomizationToggles: React.FC<CustomizationTogglesProps> = ({
               </button>
             </div>
           </div>
+        </div>
+      </div>
+
+      {/* Cheat Mode */}
+      <div style={sectionStyle}>
+        <div style={sectionTitleStyle}>⚠️ DANGER ZONE ⚠️</div>
+        
+        <div style={{ display: "flex", justifyContent: "center" }}>
+          <button
+            onClick={() => onCheatModeChange(!cheatMode)}
+            style={{
+              padding: "6px 12px",
+              fontSize: "12px",
+              backgroundColor: cheatMode ? "#ff4444" : "transparent",
+              color: cheatMode ? "#fff" : "#ff4444",
+              border: "2px solid #ff4444",
+              borderRadius: "6px",
+              cursor: "pointer",
+              fontWeight: cheatMode ? "bold" : "normal",
+              transition: "all 0.2s ease",
+            }}
+            title="Toggle cheat mode to unlock a powerful generator"
+          >
+            {cheatMode ? "💎 CHEATS ON" : "CHEATS OFF"}
+          </button>
         </div>
       </div>
     </div>

--- a/src/components/hud/Shop/Shop.tsx
+++ b/src/components/hud/Shop/Shop.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import type { GameState } from "../../../game/types";
 import type { TutorialState } from "../../../game/types/ui";
 import { getCurrentLevel } from "../../../game/systems/actions";
@@ -17,6 +17,7 @@ interface ShopProps {
   tutorialState?: TutorialState;
   onBuyGenerator?: (generatorId: string, count?: number) => void;
   onBuyUpgrade?: (upgradeId: string) => void;
+  cheatMode?: boolean;
 }
 
 export const Shop: React.FC<ShopProps> = ({
@@ -25,12 +26,20 @@ export const Shop: React.FC<ShopProps> = ({
   tutorialState,
   onBuyGenerator,
   onBuyUpgrade,
+  cheatMode = false,
 }) => {
   const [generatorFilter, setGeneratorFilter] = useState<"current" | "all">(
     "all"
   );
-  const [buyMultiplier, setBuyMultiplier] = useState<1 | 10 | 50>(1);
+  const [buyMultiplier, setBuyMultiplier] = useState<1 | 10 | 50 | 'double'>(1);
   const [sortOption, setSortOption] = useState<"price" | "value" | "level">("value");
+
+  // Auto-switch from 'double' mode when cheat mode is turned off
+  useEffect(() => {
+    if (!cheatMode && buyMultiplier === 'double') {
+      setBuyMultiplier(1);
+    }
+  }, [cheatMode, buyMultiplier]);
 
   if (!gameState || !onBuyGenerator || !onBuyUpgrade) {
     return null;
@@ -39,8 +48,18 @@ export const Shop: React.FC<ShopProps> = ({
   const currentLevel = getCurrentLevel(gameState);
 
   const handleBuyGenerator = (generatorId: string) => {
-    // Use bulk purchase function to avoid sound effect spam
-    onBuyGenerator(generatorId, buyMultiplier);
+    if (buyMultiplier === 'double') {
+      // For double mode, buy enough to double the current level
+      const currentLevel = gameState?.generators[generatorId]?.level || 0;
+      const targetLevel = currentLevel * 2;
+      const amountToBuy = targetLevel - currentLevel;
+      if (amountToBuy > 0) {
+        onBuyGenerator(generatorId, amountToBuy);
+      }
+    } else {
+      // Use bulk purchase function to avoid sound effect spam
+      onBuyGenerator(generatorId, buyMultiplier);
+    }
   };
 
   const handleBuyUpgrade = (upgradeId: string) => {
@@ -98,6 +117,7 @@ export const Shop: React.FC<ShopProps> = ({
           <BuyMultiplierToggle
             multiplier={buyMultiplier}
             onMultiplierChange={setBuyMultiplier}
+            cheatMode={cheatMode}
           />
         </div>
 
@@ -134,6 +154,7 @@ export const Shop: React.FC<ShopProps> = ({
           sortOption={sortOption}
           currentLevel={currentLevel}
           buyMultiplier={buyMultiplier}
+          cheatMode={cheatMode}
         />
 
         {/* Upgrades Component */}

--- a/src/components/hud/Shop/ShopGenerators.tsx
+++ b/src/components/hud/Shop/ShopGenerators.tsx
@@ -26,7 +26,8 @@ interface GeneratorsProps {
   generatorFilter: "current" | "all";
   sortOption: "price" | "value" | "level";
   currentLevel: { name: string };
-  buyMultiplier: 1 | 10 | 50;
+  buyMultiplier: 1 | 10 | 50 | 'double';
+  cheatMode?: boolean;
 }
 
 export const ShopGenerators: React.FC<GeneratorsProps> = ({
@@ -67,6 +68,11 @@ export const ShopGenerators: React.FC<GeneratorsProps> = ({
         // Always show tutorial generator during tutorial
         if (generator.id === "tutorial-generator") {
           return tutorialState?.isActive;
+        }
+
+        // Show cheat generator only when cheat mode is enabled
+        if (generator.id === "cheat-generator") {
+          return gameState.cheatMode;
         }
 
         if (generatorFilter === "current") {
@@ -132,6 +138,7 @@ export const ShopGenerators: React.FC<GeneratorsProps> = ({
     buyMultiplier,
     tutorialState?.isActive,
     tutorialState?.completedSteps,
+    gameState.cheatMode,
   ]);
 
   // Memoize affordability calculations to prevent unnecessary re-renders
@@ -185,6 +192,12 @@ export const ShopGenerators: React.FC<GeneratorsProps> = ({
               (g) => biomass >= calculateTotalCost(g, buyMultiplier)
             );
 
+        // Check if this is the top value generator (when sort is by value)
+        const isTopValueGenerator = 
+          sortOption === "value" && 
+          index === 0 && 
+          canAfford;
+
         return (
           <div
             key={`${generator.id}-${canAfford ? 'affordable' : 'unaffordable'}`}
@@ -194,14 +207,34 @@ export const ShopGenerators: React.FC<GeneratorsProps> = ({
                 ? `${Colors.generators.light}30` // light generator color for purchased tutorial generator
                 : generator.id === "tutorial-generator" && !isTutorialEnabled
                 ? "rgba(128, 128, 128, 0.3)" // gray for disabled tutorial generator
+                : generator.id === "cheat-generator" && gameState.cheatMode
+                ? "linear-gradient(45deg, #ff6b6b, #4ecdc4, #45b7d1, #96ceb4, #ffeaa7, #dda0dd, #98d8c8, #f7dc6f)" // animated diamond gradient
+                : isTopValueGenerator
+                ? "linear-gradient(45deg, rgba(255, 180, 0, 0.5), rgba(255, 200, 78, 0.4), rgba(255, 200, 0, 0.5), rgba(218, 140, 32, 0.6), rgba(255, 180, 0, 0.5), rgba(255, 200, 78, 0.4))" // animated gold gradient with red tint and more transparency
                 : canAfford
                 ? `${Colors.generators.primary}30`
                 : "rgba(255, 255, 255, 0.05)",
+              backgroundSize: generator.id === "cheat-generator" && gameState.cheatMode 
+                ? "400% 400%" 
+                : isTopValueGenerator 
+                ? "400% 400%" 
+                : "auto",
+              animation: generator.id === "cheat-generator" && gameState.cheatMode 
+                ? "diamondShine 3s ease-in-out infinite" 
+                : isTopValueGenerator
+                ? "goldShine 2s ease-in-out infinite"
+                : isFirstAffordable
+                ? "generatorPulse 2s ease-in-out infinite"
+                : "none",
               border: `2px solid ${
                 isTutorialPurchased
                   ? Colors.generators.light // light generator border for purchased tutorial generator
                   : generator.id === "tutorial-generator" && !isTutorialEnabled
                   ? "#666" // gray border for disabled tutorial generator
+                  : generator.id === "cheat-generator" && gameState.cheatMode
+                  ? "transparent" // transparent border for cheat generator (gradient applied via CSS)
+                  : isTopValueGenerator
+                  ? "transparent" // transparent border for top value generator
                   : canAfford
                   ? Colors.generators.primary
                   : "#666"
@@ -219,6 +252,12 @@ export const ShopGenerators: React.FC<GeneratorsProps> = ({
               position: "relative",
               transition: "all 0.3s ease-in-out",
               transform: "scale(1)",
+              color: generator.id === "cheat-generator" && gameState.cheatMode 
+                ? "#000" 
+                : "#fff", // Keep white text for all generators except cheat generator
+              fontWeight: (generator.id === "cheat-generator" && gameState.cheatMode) || isTopValueGenerator 
+                ? "bold" 
+                : "normal", // Bold text for special generators
               boxShadow: isTutorialPurchased
                 ? `0 2px 8px ${Colors.generators.light}40` // light generator shadow for purchased tutorial generator
                 : generator.id === "tutorial-generator" && !isTutorialEnabled
@@ -226,11 +265,12 @@ export const ShopGenerators: React.FC<GeneratorsProps> = ({
                 : generator.id === "tutorial-generator" &&
                   tutorialState?.currentStep?.type === "click-blob"
                 ? "none" // no shadow during click-blob phase
+                : generator.id === "cheat-generator" && gameState.cheatMode
+                ? "0 0 20px rgba(255, 107, 107, 0.6), 0 0 40px rgba(78, 205, 196, 0.4), 0 0 60px rgba(69, 183, 209, 0.2)" // diamond glow effect
+                : isTopValueGenerator
+                ? "0 0 15px rgba(255, 215, 0, 0.6), 0 0 30px rgba(255, 215, 0, 0.4), 0 0 45px rgba(255, 215, 0, 0.2)" // gold glow effect
                 : canAfford
                 ? `0 2px 8px ${Colors.generators.primary}40`
-                : "none",
-              animation: isFirstAffordable
-                ? "generatorPulse 2s ease-in-out infinite"
                 : "none",
             }}
             onClick={(e) => {
@@ -240,7 +280,7 @@ export const ShopGenerators: React.FC<GeneratorsProps> = ({
                 (generator.id !== "tutorial-generator" || isTutorialEnabled)
               ) {
                 // Calculate growth increase before purchase
-                const growthIncrease = generator.growthPerTick * buyMultiplier; // This is per tick
+                const growthIncrease = generator.growthPerTick * (buyMultiplier === 'double' ? generator.level : buyMultiplier); // This is per tick
                 const growthPerSecond =
                   growthIncrease * (1000 / GAME_CONFIG.tickRate); // Convert to per-second
 
@@ -505,6 +545,30 @@ export const ShopGenerators: React.FC<GeneratorsProps> = ({
           100% {
             box-shadow: 0 2px 8px ${Colors.generators.primary}40;
             transform: scale(1);
+          }
+        }
+
+        @keyframes diamondShine {
+          0% {
+            background-position: 0% 50%;
+          }
+          50% {
+            background-position: 100% 50%;
+          }
+          100% {
+            background-position: 0% 50%;
+          }
+        }
+
+        @keyframes goldShine {
+          0% {
+            background-position: 0% 50%;
+          }
+          50% {
+            background-position: 100% 50%;
+          }
+          100% {
+            background-position: 0% 50%;
           }
         }
       `}</style>

--- a/src/components/particles/ParticleSpawner.tsx
+++ b/src/components/particles/ParticleSpawner.tsx
@@ -311,7 +311,23 @@ export const ParticleSpawner: React.FC<ParticleSpawnerProps> = ({
     if (!currentLevel) return;
 
     const spawnInterval = setInterval(() => {
-      const shouldSpawn = Math.random() < (particleConfig.spawnRate * 0.4) / 60; // 60fps, reduced to 40% of original
+      // PERFORMANCE OPTIMIZATION: Apply particle density setting to spawn rate
+      // This prevents excessive particle spawning when cheat mode is enabled with millions of generators
+      // The high biomass from cheat generators would otherwise cause extremely high spawn rates
+      let densityMultiplier = 1.0;
+      switch (particleDensity) {
+        case "low":
+          densityMultiplier = 0.3;
+          break;
+        case "medium":
+          densityMultiplier = 1.0;
+          break;
+        case "high":
+          densityMultiplier = 2.0;
+          break;
+      }
+
+      const shouldSpawn = Math.random() < (particleConfig.spawnRate * 0.4 * densityMultiplier) / 60; // 60fps, reduced to 40% of original
 
       if (shouldSpawn) {
         const newParticle = spawnOffScreenParticle(
@@ -323,7 +339,7 @@ export const ParticleSpawner: React.FC<ParticleSpawnerProps> = ({
     }, 16); // 60fps
 
     return () => clearInterval(spawnInterval);
-  }, [particleConfig, blobPosition, currentLevel]);
+  }, [particleConfig, blobPosition, currentLevel, particleDensity]);
 
   // Combined animation loop for particles and bursts (Performance optimization)
   useEffect(() => {

--- a/src/game/content/generators.ts
+++ b/src/game/content/generators.ts
@@ -8,6 +8,7 @@ export const GENERATORS: Record<string, Omit<GeneratorState, 'level'>> = {
     baseCost: 10,
     description: 'Clones basic slime cells',
     growthPerTick: 2,
+    // growthPerTick: 2000000000000000,
     costMultiplier: 1.08, // Reduced from 1.20 to prevent fast scaling
     unlockedAtLevel: 'microscopic'
   },
@@ -161,5 +162,16 @@ export const GENERATORS: Record<string, Omit<GeneratorState, 'level'>> = {
     growthPerTick: 1,
     costMultiplier: 1.0,
     unlockedAtLevel: 'intro'
+  },
+
+  // Cheat Generator (only available in cheat mode)
+  'cheat-generator': {
+    id: 'cheat-generator',
+    name: '💎 Cheat Code',
+    baseCost: 1,
+    description: 'Produces unfair amounts of biomass instantly',
+    growthPerTick: 100000000000000000000, // 100 quintillion per second
+    costMultiplier: 1.0,
+    unlockedAtLevel: 'intro' // Available from the start when cheat mode is on
   }
 }; 

--- a/src/game/content/upgrades.ts
+++ b/src/game/content/upgrades.ts
@@ -1,6 +1,17 @@
 import type { UpgradeState } from '../types';
 
 export const UPGRADES: Record<string, Omit<UpgradeState, 'purchased'>> = {
+  // Tutorial Upgrade (always available)
+  'tutorial-upgrade': {
+    id: 'tutorial-upgrade',
+    name: '🎓 Tutorial Upgrade',
+    description: 'Doubles your click power',
+    cost: 0,
+    effect: 2,
+    type: 'click',
+    unlockedAtLevel: 'intro'
+  },
+
   // Microscopic Level
   'enhanced-microscope-optics': {
     id: 'enhanced-microscope-optics',

--- a/src/game/systems/actions.ts
+++ b/src/game/systems/actions.ts
@@ -6,7 +6,6 @@ import { playSound } from '../../utils/sound';
 import {
     checkSizeMilestones,
     checkFirstGenerator,
-    checkFirstUpgrade,
     checkClickMilestones,
     incrementClickCount,
     displayNotification
@@ -93,6 +92,25 @@ export function buyGenerator(state: GameState, generatorId: string, playSoundEff
         };
     }
 
+    // Cheat generator is free and purchasable when cheat mode is on
+    if (generatorId === 'cheat-generator' && state.cheatMode) {
+        // Play UI click sound for generator purchase
+        if (playSoundEffect) {
+            playSound('uiClick');
+        }
+
+        return {
+            ...state,
+            generators: {
+                ...state.generators,
+                [generatorId]: {
+                    ...generator,
+                    level: generator.level + 1
+                }
+            }
+        };
+    }
+
     const cost = generator.baseCost * Math.pow(generator.costMultiplier, generator.level);
 
     if (state.biomass >= cost) {
@@ -128,54 +146,57 @@ export function buyGenerator(state: GameState, generatorId: string, playSoundEff
     return state;
 }
 
-export function buyGeneratorsBulk(state: GameState, generatorId: string, count: number): GameState {
+export function buyGeneratorsBulk(state: GameState, generatorId: string, count: number | 'double'): GameState {
     const generator = state.generators[generatorId];
     if (!generator) return state;
 
-    let currentState = state;
-    let totalCost = 0;
-    let canAfford = true;
-
-    // Calculate total cost first
-    for (let i = 0; i < count; i++) {
-        const level = generator.level + i;
-        const cost = generator.baseCost * Math.pow(generator.costMultiplier, level);
-        totalCost += cost;
-        if (totalCost > currentState.biomass) {
-            canAfford = false;
-            break;
-        }
+    // Calculate how many to buy
+    let amountToBuy: number;
+    if (count === 'double') {
+        const currentLevel = generator.level;
+        const targetLevel = currentLevel * 2;
+        amountToBuy = targetLevel - currentLevel;
+        if (amountToBuy <= 0) return state; // Already at or above double level
+    } else {
+        amountToBuy = count;
     }
 
-    if (!canAfford) {
-        return state; // Can't afford all purchases
-    }
+    // Calculate total cost
+    const totalCost = calculateTotalCost(generator, count);
+    
+    if (state.biomass < totalCost) return state;
 
-    // Tutorial generator is always free and purchasable
-    if (generatorId === 'tutorial-generator') {
-        // Play UI click sound for tutorial generator purchase
-        playSound('uiClick');
+    // PERFORMANCE OPTIMIZATION: Play sound effect ONCE for the entire purchase
+    // This prevents sound effect spam when buying millions of generators
+    // The sound is played before the purchase logic to ensure it always plays exactly once
+    playSound('uiClick');
 
+    // Special handling for cheat generator (always free when cheat mode is on)
+    if (generatorId === 'cheat-generator' && state.cheatMode) {
         return {
             ...state,
             generators: {
                 ...state.generators,
                 [generatorId]: {
                     ...generator,
-                    level: generator.level + count
+                    level: generator.level + amountToBuy
                 }
             }
         };
     }
 
-    // Perform bulk purchase
-    for (let i = 0; i < count; i++) {
-        // Only play sound effect for first purchase and every 5th purchase after that
-        const shouldPlaySound = i === 0 || (i + 1) % 5 === 0;
-        currentState = buyGenerator(currentState, generatorId, shouldPlaySound);
-    }
-
-    return currentState;
+    // Regular purchase
+    return {
+        ...state,
+        biomass: state.biomass - totalCost,
+        generators: {
+            ...state.generators,
+            [generatorId]: {
+                ...generator,
+                level: generator.level + amountToBuy
+            }
+        }
+    };
 }
 
 export function buyUpgrade(state: GameState, upgradeId: string): GameState {
@@ -184,32 +205,25 @@ export function buyUpgrade(state: GameState, upgradeId: string): GameState {
 
     // Tutorial upgrade is always free and purchasable
     if (upgradeId === 'tutorial-upgrade') {
-        if (!upgrade.purchased) {
-            // Play UI click sound for upgrade purchase
-            playSound('uiClick');
-
-            return {
-                ...state,
-                upgrades: {
-                    ...state.upgrades,
-                    [upgradeId]: {
-                        ...upgrade,
-                        purchased: true
-                    }
+        playSound('uiClick');
+        return {
+            ...state,
+            upgrades: {
+                ...state.upgrades,
+                [upgradeId]: {
+                    ...upgrade,
+                    purchased: true
                 }
-            };
-        }
-        return state;
+            }
+        };
     }
 
-    if (!upgrade.purchased && state.biomass >= upgrade.cost) {
-        // Play UI click sound for upgrade purchase
+    if (state.biomass >= upgrade.cost && !upgrade.purchased) {
         playSound('uiClick');
-
         const newBiomass = state.biomass - upgrade.cost;
         const clickPower = calculateClickPower({ ...state, biomass: newBiomass });
 
-        const updatedState = {
+        return {
             ...state,
             biomass: newBiomass,
             clickPower,
@@ -221,13 +235,6 @@ export function buyUpgrade(state: GameState, upgradeId: string): GameState {
                 }
             }
         };
-
-        const result = checkFirstUpgrade(updatedState);
-        if (result.notification) {
-            displayNotification(result.notification.message, result.notification.id);
-        }
-
-        return result.state;
     }
 
     return state;
@@ -267,9 +274,41 @@ export function evolveToNextLevel(state: GameState): GameState {
         ...state,
         currentLevelId: nextLevel.id,
         highestLevelReached: nextLevel.id,
-        isGameCompleted: isFinalLevel ? true : state.isGameCompleted
+        isGameCompleted: isFinalLevel ? true : state.isGameCompleted,
+        hasShownEndingVideo: isFinalLevel ? false : state.hasShownEndingVideo
         // Biomass carries over, generators and upgrades are preserved
         // Zoom reset is handled by useCameraZoom hook when currentLevelId changes
+    };
+}
+
+// Transition to endless mode after game completion
+export function transitionToEndlessMode(state: GameState): GameState {
+    return {
+        ...state,
+        gameMode: 'endless',
+        hasShownEndingVideo: true,
+        // Keep isGameCompleted as true since the game is still completed
+        // Keep all other state (biomass, generators, upgrades, etc.)
+    };
+}
+
+// Toggle cheat mode
+export function toggleCheatMode(state: GameState): GameState {
+    const newCheatMode = !state.cheatMode;
+    
+    // If turning cheat mode off, "sell" all cheat generators (reset to 0)
+    const updatedGenerators = { ...state.generators };
+    if (!newCheatMode && state.generators['cheat-generator']) {
+        updatedGenerators['cheat-generator'] = {
+            ...state.generators['cheat-generator'],
+            level: 0
+        };
+    }
+    
+    return {
+        ...state,
+        cheatMode: newCheatMode,
+        generators: updatedGenerators,
     };
 }
 
@@ -297,7 +336,23 @@ export function isContentAvailable(unlockedAtLevel: string, currentLevelName: st
 }
 
 // Calculate total cost for buying multiple generators (from incoming branch)
-export function calculateTotalCost(generator: { baseCost: number; costMultiplier: number; level: number }, count: number): number {
+export function calculateTotalCost(generator: { baseCost: number; costMultiplier: number; level: number }, count: number | 'double'): number {
+    if (count === 'double') {
+        // For double mode, calculate cost to double the current level
+        const currentLevel = generator.level;
+        const targetLevel = currentLevel * 2;
+        const amountToBuy = targetLevel - currentLevel;
+        
+        let totalCost = 0;
+        for (let i = 0; i < amountToBuy; i++) {
+            const levelToBuy = currentLevel + i;
+            const cost = generator.baseCost * Math.pow(generator.costMultiplier, levelToBuy);
+            totalCost += cost;
+        }
+        return totalCost;
+    }
+    
+    // Regular count calculation
     let totalCost = 0;
     for (let i = 0; i < count; i++) {
         const currentLevel = generator.level + i;

--- a/src/game/systems/calculations.ts
+++ b/src/game/systems/calculations.ts
@@ -6,11 +6,18 @@ export function getGeneratorCost(generator: GeneratorState): number {
 }
 
 export function getTotalGrowth(state: GameState): number {
+    let finalGrowth = 0;
+    
     // Group generators by level
     const generatorsByLevel: Record<string, GeneratorState[]> = {};
     Object.values(state.generators).forEach((gen) => {
         // Skip tutorial content
         if (gen.id === 'tutorial-generator') {
+            return;
+        }
+
+        // Skip generators with 0 level (no contribution)
+        if (gen.level === 0) {
             return;
         }
 
@@ -29,7 +36,6 @@ export function getTotalGrowth(state: GameState): number {
     });
 
     // Apply upgrades to specific levels
-    let finalGrowth = 0;
     Object.entries(baseGrowthByLevel).forEach(([level, baseGrowth]) => {
         let levelGrowth = baseGrowth;
 

--- a/src/game/systems/initialization.ts
+++ b/src/game/systems/initialization.ts
@@ -60,6 +60,8 @@ export const INITIAL_STATE: GameState = {
     highestLevelReached: 0,
     gameMode: 'tutorial',
     isGameCompleted: false,
+    hasShownEndingVideo: false,
+    cheatMode: false,
     notifications: {
         shownMilestones: new Set<string>(),
         totalClicks: 0,

--- a/src/game/types/components.ts
+++ b/src/game/types/components.ts
@@ -55,7 +55,9 @@ export interface GameHUDProps {
   musicVolume?: number;
   onMusicVolumeChange?: (value: number) => void;
   
-
+  // Cheat mode
+  cheatMode?: boolean;
+  onCheatModeChange?: (value: boolean) => void;
 }
 
 export interface GameStatsProps {

--- a/src/game/types/core.ts
+++ b/src/game/types/core.ts
@@ -15,6 +15,8 @@ export interface GameState {
   highestLevelReached: number
   gameMode: 'tutorial' | 'main' | 'endless'
   isGameCompleted: boolean
+  hasShownEndingVideo: boolean
+  cheatMode: boolean
   notifications: {
     shownMilestones: Set<string>
     totalClicks: number

--- a/src/hooks/useGame.ts
+++ b/src/hooks/useGame.ts
@@ -7,6 +7,8 @@ import {
   buyGeneratorsBulk,
   buyUpgrade,
   evolveToNextLevel,
+  transitionToEndlessMode,
+  toggleCheatMode,
   type GameState
 } from '../game/systems/actions';
 import { GAME_CONFIG } from '../game/content/config';
@@ -56,7 +58,10 @@ export const useGame = () => {
     // Only switch themes when tutorial is NOT active
     const currentLevelId = gameState.currentLevelId;
     
-    if (currentLevelId >= 1 && currentLevelId <= 4) {
+    if (gameState.gameMode === 'endless') {
+      // Keep final theme in endless mode
+      switchMusicTheme('finalTheme', 0.24);
+    } else if (currentLevelId >= 1 && currentLevelId <= 4) {
       // Microscopic, Petri Dish, Lab, Neighborhood
       switchMusicTheme('earlyTheme', 0.24);
     } else if (currentLevelId >= 5 && currentLevelId <= 7) {
@@ -66,7 +71,7 @@ export const useGame = () => {
       // Solar System and beyond
       switchMusicTheme('finalTheme', 0.24);
     }
-  }, [gameState.currentLevelId, tutorialState.isActive]);
+  }, [gameState.currentLevelId, gameState.gameMode, tutorialState.isActive]);
 
   // Game loop
   useEffect(() => {
@@ -124,6 +129,21 @@ export const useGame = () => {
     setTutorialState((prevTutorialState: TutorialState) => progressTutorial(prevTutorialState, 'evolve'));
   }, [gameState]);
 
+  const handleTransitionToEndless = useCallback(() => {
+    setGameState(prevState => transitionToEndlessMode(prevState));
+  }, []);
+
+  const handleMarkVideoShown = useCallback(() => {
+    setGameState(prevState => ({
+      ...prevState,
+      hasShownEndingVideo: true
+    }));
+  }, []);
+
+  const handleToggleCheatMode = useCallback(() => {
+    setGameState(prevState => toggleCheatMode(prevState));
+  }, []);
+
   const handleTutorialStepComplete = useCallback((stepId: string) => {
     setTutorialState((prevTutorialState: TutorialState) => {
       const newTutorialState = { ...prevTutorialState };
@@ -175,6 +195,9 @@ export const useGame = () => {
     handleBuyGenerator,
     handleBuyUpgrade,
     handleEvolve,
+    handleTransitionToEndless,
+    handleMarkVideoShown,
+    handleToggleCheatMode,
     handleTutorialStepComplete,
   };
 }; 

--- a/src/utils/persistence.ts
+++ b/src/utils/persistence.ts
@@ -30,6 +30,8 @@ export const loadGameState = (): GameState | null => {
       // Reconstruct Set objects that were serialized as arrays
       const reconstructedState = {
         ...parsed,
+        hasShownEndingVideo: parsed.hasShownEndingVideo ?? false, // Default to false for backward compatibility
+        cheatMode: parsed.cheatMode ?? false, // Default to false for backward compatibility
         notifications: {
           ...parsed.notifications,
           shownMilestones: new Set(parsed.notifications?.shownMilestones || []),


### PR DESCRIPTION
- Add 2x toggle option in Buy X multiplier when cheat mode is enabled
- Implement animated diamond gradient for 2x button with shimmer effect
- Add smart doubling logic that doubles generator levels (e.g., 5->10, 0->1)
- Fix performance issues with millions of generators:
  - Single sound effect per purchase (no audio spam)
  - Particle density setting properly controls spawn rate
  - Optimize shop rendering for large generator counts
- Add auto-switch logic: 2x mode reverts to Buy 1 when cheat mode is disabled
- Fix video reopening issue and add rewatch button for endless mode
- Remove unused checkFirstUpgrade import to fix build error